### PR TITLE
Call encodeURIComponent() when creating get parameter (issue #16)

### DIFF
--- a/scripts/components/App.js
+++ b/scripts/components/App.js
@@ -64,7 +64,7 @@ export default class App extends React.Component {
   }
 
   fetchData(params) {
-    const query = Object.keys(params).map(k => `${k}=${params[k]}`).join('&');
+    const query = Object.keys(params).map(k => `${k}=${encodeURIComponent(params[k])}`).join('&');
     this.setState(Object.assign({}, this.state, { isFetching: true }));
     return window.fetch(`./network/commits?${query}`, { credentials: 'include' }).then(
       r => r.json()


### PR DESCRIPTION
Now I'm trying this plugin.
I found the issue #16 and modified JS code.

The issue reporter created branch named `feature/#1`.

Expected request is `commits?count=100&branch=feature/#1`,
But actual one is `commits?count=100&branch=feature/`.
It seems that it is because `#1` is handled as hash of URL.

I think it is enough to call `encodeURIComponent()`.

Request will be `commits?count=100&branch=feature%2F%231`.